### PR TITLE
Update ToDo fields list

### DIFF
--- a/models/doctype/ToDo/ToDo.js
+++ b/models/doctype/ToDo/ToDo.js
@@ -60,5 +60,11 @@ module.exports = {
                 await form.doc.update();
             }
         }
-    ]
+    ],
+
+    listSettings: {
+        getFields(list) {
+            return ['subject']
+        }
+    }
 }


### PR DESCRIPTION
Currently, the title of rows in the ToDo doctype is `undefined` because the title field (subject) is not the field list, and is hence not retrieved from the backend.
![image](https://user-images.githubusercontent.com/22165016/42133841-00cc413c-7d4e-11e8-9daf-ed3b59539d87.png)

After the fix:
![image](https://user-images.githubusercontent.com/22165016/42133843-09be844e-7d4e-11e8-8758-e6668f3ab871.png)
