### PR TITLE
Add error modal

### DIFF
--- a/common/errors.js
+++ b/common/errors.js
@@ -1,3 +1,5 @@
+const frappe = require('frappejs');
+
 class BaseError extends Error {
     constructor(statusCode, ...params) {
         super(...params);
@@ -38,6 +40,8 @@ function throwError(message, error='ValidationError') {
     frappe.events.trigger('throw', { message, stackTrace: err.stack });
     throw err;
 }
+
+frappe.throw = throwError;
 
 module.exports = {
     ValidationError,

--- a/common/errors.js
+++ b/common/errors.js
@@ -26,10 +26,24 @@ class Forbidden extends BaseError {
 class ValueError extends ValidationError { }
 class Conflict extends ValidationError { }
 
+function throwError(message, error='ValidationError') {
+    const errorClass = {
+        'ValidationError': ValidationError,
+        'NotFound': NotFound,
+        'Forbidden': Forbidden,
+        'ValueError': ValueError,
+        'Conflict': Conflict
+    };
+    const err = new errorClass[error](message);
+    frappe.events.trigger('throw', { message, stackTrace: err.stack });
+    throw err;
+}
+
 module.exports = {
     ValidationError,
     ValueError,
     Conflict,
     NotFound,
-    Forbidden
+    Forbidden,
+    throw: throwError
 }

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = {
         this.initConfig();
         this.initGlobals();
         this.docs = new Observable();
+        this.events = new Observable();
         this._initialized = true;
     },
 

--- a/ui/components/Modal/ErrorModal.vue
+++ b/ui/components/Modal/ErrorModal.vue
@@ -1,0 +1,20 @@
+<template>
+<div class="modal-body">
+    <p v-if="message">{{message}}</p>
+    <div v-if="stackTrace"><hr>
+        <textarea v-model="stackTrace" disabled></textarea>
+    </div>
+</div>
+</template>
+<script>
+export default {
+    props: ["message", "stackTrace"]
+}
+</script>
+<style scoped>
+    textarea {
+        width: 100%;
+        height: 40vh;
+        padding: 1%
+    }
+</style>

--- a/ui/components/Modal/Modal.vue
+++ b/ui/components/Modal/Modal.vue
@@ -12,7 +12,7 @@
         <div class="modal-body modal-height p-0">
           <component ref="modalComponent" :is="component" v-bind="props" v-on="events"/>
         </div>
-        <div class="modal-footer">
+        <div class="modal-footer" v-if="!noFooter">
           <!-- <f-button secondary @click="closeModal">{{ _('Close') }}</f-button> -->
           <f-button primary v-if="primaryAction" @click="onPrimaryAction">{{ primaryAction.label }}</f-button>
         </div>
@@ -41,6 +41,10 @@ export default {
       type: Object
     },
     noHeader: {
+      type: Boolean,
+      default: false
+    },
+    noFooter: {
       type: Boolean,
       default: false
     }

--- a/ui/components/Modal/ModalContainer.vue
+++ b/ui/components/Modal/ModalContainer.vue
@@ -12,6 +12,7 @@
 <script>
 import Modal from './Modal';
 import Plugin from './plugin';
+import ErrorModal from './ErrorModal';
 
 export default {
   name: 'ModalContainer',
@@ -32,6 +33,20 @@ export default {
         console.warn(`id not provided in $modal.hide method, the last modal in the stack will be hidden`);
       }
       this.onModalClose(id);
+    });
+
+    frappe.events.on('throw', ({ message, stackTrace }) => {
+      	this.$modal.show({
+          modalProps: {
+            title: 'Something went wrong',
+            noFooter: true
+          },
+          component: ErrorModal,
+          props: {
+            message,
+            stackTrace
+          }
+      });
     });
   },
   methods: {

--- a/ui/components/Modal/ModalContainer.vue
+++ b/ui/components/Modal/ModalContainer.vue
@@ -1,13 +1,13 @@
 <template>
-  <div class="modal-container">
+    <div class="modal-container">
     <modal
-      :key="modal.id"
-      v-for="modal in modals"
-      v-bind="modal.modalProps"
-      @close-modal="onModalClose(modal.id)"
+        :key="modal.id"
+        v-for="modal in modals"
+        v-bind="modal.modalProps"
+        @close-modal="onModalClose(modal.id)"
     ></modal>
     <div class="modal-backdrop show" v-show="modals.length"></div>
-  </div>
+    </div>
 </template>
 <script>
 import Modal from './Modal';
@@ -15,67 +15,67 @@ import Plugin from './plugin';
 import ErrorModal from './ErrorModal';
 
 export default {
-  name: 'ModalContainer',
-  components: {
-    Modal
-  },
-  data() {
-    return {
-      currentId: 0,
-      modals: []
-    }
-  },
-  created() {
-    Plugin.modalContainer = this;
-
-    Plugin.event.$on('hide', (id) => {
-      if (!id) {
-        console.warn(`id not provided in $modal.hide method, the last modal in the stack will be hidden`);
-      }
-      this.onModalClose(id);
-    });
-
-    frappe.events.on('throw', ({ message, stackTrace }) => {
-      	this.$modal.show({
-          modalProps: {
-            title: 'Something went wrong',
-            noFooter: true
-          },
-          component: ErrorModal,
-          props: {
-            message,
-            stackTrace
-          }
-      });
-    });
-  },
-  methods: {
-    add({ component, props = {}, events = {}, modalProps = {} }) {
-      this.currentId++;
-      this.modals.push({
-        id: this.currentId,
-        modalProps: Object.assign({}, modalProps, {
-          component,
-          props,
-          events
-        })
-      });
-      return this.currentId;
+    name: 'ModalContainer',
+    components: {
+        Modal
     },
-    removeModal(id) {
-      if (!id) {
-        id = this.currentId;
-      }
-      this.currentId--;
-      this.modals = this.modals.filter(modal => modal.id !== id);
+    data() {
+        return {
+            currentId: 0,
+            modals: []
+        }
     },
-    onModalClose(id) {
-      if (id) {
-        const modal = this.modals.find(modal => modal.id === id);
-        modal.modalProps.events.onClose && modal.modalProps.events.onClose();
-      }
-      this.removeModal(id);
+    created() {
+        Plugin.modalContainer = this;
+
+        Plugin.event.$on('hide', (id) => {
+            if (!id) {
+                console.warn(`id not provided in $modal.hide method, the last modal in the stack will be hidden`);
+            }
+            this.onModalClose(id);
+        });
+
+        frappe.events.on('throw', ({ message, stackTrace }) => {
+            this.$modal.show({
+                modalProps: {
+                    title: 'Something went wrong',
+                    noFooter: true
+                },
+                component: ErrorModal,
+                props: {
+                    message,
+                    stackTrace
+                }
+            });
+        });
+    },
+    methods: {
+        add({ component, props = {}, events = {}, modalProps = {} }) {
+            this.currentId++;
+            this.modals.push({
+                id: this.currentId,
+                modalProps: Object.assign({}, modalProps, {
+                    component,
+                    props,
+                    events
+                })
+            });
+            return this.currentId;
+        },
+        removeModal(id) {
+            if (!id) {
+                id = this.currentId;
+            }
+            this.currentId--;
+            this.modals = this.modals.filter(modal => modal.id !== id);
+        },
+        onModalClose(id) {
+            if (id) {
+                const modal = this.modals.find(modal => modal.id === id);
+                modal.modalProps.events.onClose && modal.modalProps.events.onClose();
+            }
+            this.removeModal(id);
+        }
     }
-  }
 }
 </script>

--- a/ui/components/Modal/ModalContainer.vue
+++ b/ui/components/Modal/ModalContainer.vue
@@ -1,81 +1,78 @@
 <template>
-    <div class="modal-container">
+  <div class="modal-container">
     <modal
-        :key="modal.id"
-        v-for="modal in modals"
-        v-bind="modal.modalProps"
-        @close-modal="onModalClose(modal.id)"
+      :key="modal.id"
+      v-for="modal in modals"
+      v-bind="modal.modalProps"
+      @close-modal="onModalClose(modal.id)"
     ></modal>
     <div class="modal-backdrop show" v-show="modals.length"></div>
-    </div>
+  </div>
 </template>
 <script>
 import Modal from './Modal';
 import Plugin from './plugin';
 import ErrorModal from './ErrorModal';
-
 export default {
-    name: 'ModalContainer',
-    components: {
-        Modal
-    },
-    data() {
-        return {
-            currentId: 0,
-            modals: []
-        }
-    },
-    created() {
-        Plugin.modalContainer = this;
-
-        Plugin.event.$on('hide', (id) => {
-            if (!id) {
-                console.warn(`id not provided in $modal.hide method, the last modal in the stack will be hidden`);
-            }
-            this.onModalClose(id);
-        });
-
-        frappe.events.on('throw', ({ message, stackTrace }) => {
-            this.$modal.show({
-                modalProps: {
-                    title: 'Something went wrong',
-                    noFooter: true
-                },
-                component: ErrorModal,
-                props: {
-                    message,
-                    stackTrace
-                }
-            });
-        });
-    },
-    methods: {
-        add({ component, props = {}, events = {}, modalProps = {} }) {
-            this.currentId++;
-            this.modals.push({
-                id: this.currentId,
-                modalProps: Object.assign({}, modalProps, {
-                    component,
-                    props,
-                    events
-                })
-            });
-            return this.currentId;
-        },
-        removeModal(id) {
-            if (!id) {
-                id = this.currentId;
-            }
-            this.currentId--;
-            this.modals = this.modals.filter(modal => modal.id !== id);
-        },
-        onModalClose(id) {
-            if (id) {
-                const modal = this.modals.find(modal => modal.id === id);
-                modal.modalProps.events.onClose && modal.modalProps.events.onClose();
-            }
-            this.removeModal(id);
-        }
+  name: 'ModalContainer',
+  components: {
+    Modal
+  },
+  data() {
+    return {
+      currentId: 0,
+      modals: []
     }
+  },
+  created() {
+    Plugin.modalContainer = this;
+    Plugin.event.$on('hide', (id) => {
+      if (!id) {
+        console.warn(`id not provided in $modal.hide method, the last modal in the stack will be hidden`);
+      }
+      this.onModalClose(id);
+    });
+    frappe.events.on('throw', ({ message, stackTrace }) => {
+      this.$modal.show({
+        modalProps: {
+          title: 'Something went wrong',
+          noFooter: true
+        },
+        component: ErrorModal,
+        props: {
+          message,
+          stackTrace
+        }
+      }); 
+    });
+  },
+  methods: {
+    add({ component, props = {}, events = {}, modalProps = {} }) {
+      this.currentId++;
+      this.modals.push({
+        id: this.currentId,
+        modalProps: Object.assign({}, modalProps, {
+          component,
+          props,
+          events
+        })
+      });
+      return this.currentId;
+    },
+    removeModal(id) {
+      if (!id) {
+        id = this.currentId;
+      }
+      this.currentId--;
+      this.modals = this.modals.filter(modal => modal.id !== id);
+    },
+    onModalClose(id) {
+      if (id) {
+        const modal = this.modals.find(modal => modal.id === id);
+        modal.modalProps.events.onClose && modal.modalProps.events.onClose();
+      }
+      this.removeModal(id);
+    }
+  }
 }
 </script>


### PR DESCRIPTION
Added error handling function that displays the error message and stack trace on a modal. Also throws the error in console.

# Usage
`frappe.throw('Error message', 'Type of error');`

# Example
`frappe.throw('The server does not exist or is not live', 'NotFound');`

![error-modal](https://user-images.githubusercontent.com/22641196/44913661-a65c0100-ad4b-11e8-9123-a7069d6e9f0e.png)

![error-console](https://user-images.githubusercontent.com/22641196/44914375-b1b02c00-ad4d-11e8-81f4-7b3319259b08.png)