### PR TITLE
Fix values not updating in a single doctype

### DIFF
--- a/backends/database.js
+++ b/backends/database.js
@@ -280,7 +280,7 @@ module.exports = class Database extends Observable {
   }
 
   async updateSingle(meta, doc, doctype) {
-    await this.deleteSingleValues();
+    await this.deleteSingleValues(doctype);
     for (let field of meta.getValidFields({ withChildren: false })) {
       let value = doc[field.fieldname];
       if (value) {


### PR DESCRIPTION
When performing an update operation on a single doctype, altogether a new document was getting inserted in the SingleValue table instead of updating the desired field of the single doctype in consideration.

The issue was with the name of single doctype not being passed as a parameter to deleteSingleValues function. Hence, the fields of the doctype were not getting deleted before inserting the modified doctype.