### PR TITLE
fix(ux): add items in system settings, move auto update to system

### DIFF
--- a/models/doctype/SystemSettings/SystemSettings.js
+++ b/models/doctype/SystemSettings/SystemSettings.js
@@ -1,4 +1,5 @@
 const { DateTime } = require('luxon');
+const { _ } = require('frappejs/utils');
 
 let dateFormatOptions = (() => {
   let formats = [
@@ -8,15 +9,15 @@ let dateFormatOptions = (() => {
     'MM-dd-yyyy',
     'yyyy-MM-dd',
     'd MMM, y',
-    'MMM d, y'
+    'MMM d, y',
   ];
 
   let today = DateTime.local();
 
-  return formats.map(format => {
+  return formats.map((format) => {
     return {
       label: today.toFormat(format),
-      value: format
+      value: format,
     };
   });
 })();
@@ -35,7 +36,7 @@ module.exports = {
       fieldtype: 'Select',
       options: dateFormatOptions,
       default: 'MMM d, y',
-      required: 1
+      required: 1,
     },
     {
       fieldname: 'floatPrecision',
@@ -43,10 +44,28 @@ module.exports = {
       fieldtype: 'Select',
       options: ['2', '3', '4', '5'],
       default: '2',
-      required: 1
+      required: 1,
+    },
+    {
+      fieldname: 'hideGetStarted',
+      label: 'Hide Get Started',
+      fieldtype: 'Check',
+      default: 0,
+    },
+    {
+      fieldname: 'autoUpdate',
+      label: 'Auto Update',
+      fieldtype: 'Check',
+      default: 1,
+      description: _(
+        'Automatically check for updates and download them if available. The update will be applied after you restart the app.'
+      ),
     },
   ],
   quickEditFields: [
-    'dateFormat'
-  ]
+    'dateFormat',
+    'floatPrecision',
+    'hideGetStarted',
+    'autoUpdate',
+  ],
 };


### PR DESCRIPTION
cross ref: https://github.com/frappe/books/pull/257

A few books related settings have been entered in system settings, these will be removed later on when the division between FrappeJS and Books is more clear.