### PR TITLE
refactor: deprecate underscore translate

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -1,5 +1,5 @@
 const { pesa } = require('pesa');
-const { T } = require('./translation');
+const { T, t } = require('./translation');
 
 Array.prototype.equals = function (array) {
   return (
@@ -55,7 +55,9 @@ function asyncHandler(fn) {
  * @param {Number} n
  */
 function range(n) {
-  return Array.from(Array(4)).map((d, i) => i);
+  return Array(n)
+    .fill()
+    .map((_, i) => i);
 }
 
 function unique(list, key = (it) => it) {
@@ -86,7 +88,8 @@ function isPesa(value) {
 }
 
 module.exports = {
-  _: T,
+  _: t,
+  t,
   T,
   slug,
   getRandomString,

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,4 +1,5 @@
 const { pesa } = require('pesa');
+const { T } = require('./translation');
 
 Array.prototype.equals = function (array) {
   return (
@@ -24,30 +25,6 @@ function getRandomString() {
 async function sleep(seconds) {
   return new Promise((resolve) => {
     setTimeout(resolve, seconds * 1000);
-  });
-}
-
-function _(text, args) {
-  // should return translated text
-  return stringReplace(text, args);
-}
-
-function stringReplace(str, args) {
-  if (!Array.isArray(args)) {
-    args = [args];
-  }
-
-  if (str == undefined) return str;
-
-  let unkeyed_index = 0;
-  return str.replace(/\{(\w*)\}/g, (match, key) => {
-    if (key === '') {
-      key = unkeyed_index;
-      unkeyed_index++;
-    }
-    if (key == +key) {
-      return args[key] !== undefined ? args[key] : match;
-    }
   });
 }
 
@@ -109,11 +86,11 @@ function isPesa(value) {
 }
 
 module.exports = {
-  _,
+  _: T,
+  T,
   slug,
   getRandomString,
   sleep,
-  stringReplace,
   getQueryString,
   asyncHandler,
   range,

--- a/utils/translation.js
+++ b/utils/translation.js
@@ -59,7 +59,7 @@ class TranslationString {
   }
 }
 
-function T(...args) {
+export function T(...args) {
   if (typeof args[0] === 'string') {
     return stringReplace(args[0], args.slice(1));
   }

--- a/utils/translation.js
+++ b/utils/translation.js
@@ -1,0 +1,68 @@
+function stringReplace(str, args) {
+  if (!Array.isArray(args)) {
+    args = [args];
+  }
+
+  if (str == undefined) return str;
+
+  let unkeyed_index = 0;
+  return str.replace(/\{(\w*)\}/g, (match, key) => {
+    if (key === '') {
+      key = unkeyed_index;
+      unkeyed_index++;
+    }
+    if (key == +key) {
+      return args[key] !== undefined ? args[key] : match;
+    }
+  });
+}
+
+class TranslationString {
+  constructor(...args) {
+    this.args = args;
+  }
+
+  get s() {
+    return this.toString();
+  }
+
+  ctx(context) {
+    this.context = context;
+    return this;
+  }
+
+  #translate(segment) {
+    if (this.context) {
+      // do something
+    }
+    return segment;
+  }
+
+  #stitch() {
+    const strList = this.args[0];
+    const argList = this.args.slice(1);
+    return strList
+      .map((s, i) => this.#translate(s) + (argList[i] ?? ''))
+      .join('');
+  }
+
+  toString() {
+    return this.#stitch();
+  }
+
+  toJSON() {
+    return this.#stitch();
+  }
+
+  valueOf() {
+    return this.#stitch();
+  }
+}
+
+function T(...args) {
+  if (typeof args[0] === 'string') {
+    return stringReplace(args[0], args.slice(1));
+  }
+
+  return new TranslationString(...args);
+}

--- a/utils/translation.js
+++ b/utils/translation.js
@@ -1,3 +1,5 @@
+import { ValueError } from '../common/errors';
+
 function stringReplace(str, args) {
   if (!Array.isArray(args)) {
     args = [args];
@@ -32,13 +34,23 @@ class TranslationString {
   }
 
   #translate(segment) {
-    if (this.context) {
-      // do something
-    }
+    // TODO: implement translation backend
     return segment;
   }
 
   #stitch() {
+    if (typeof this.args[0] === 'string') {
+      return stringReplace(this.args[0], this.args.slice(1));
+    }
+
+    if (!(this.args[0] instanceof Array)) {
+      throw new ValueError(
+        `invalid args passed to TranslationString ${
+          this.args
+        } of type ${typeof this.args[0]}`
+      );
+    }
+
     const strList = this.args[0];
     const argList = this.args.slice(1);
     return strList
@@ -60,9 +72,9 @@ class TranslationString {
 }
 
 export function T(...args) {
-  if (typeof args[0] === 'string') {
-    return stringReplace(args[0], args.slice(1));
-  }
-
   return new TranslationString(...args);
+}
+
+export function t(...args) {
+  return new TranslationString(...args).s;
 }


### PR DESCRIPTION
Was never a fan of `_("some string {1}.", someArg)`, feels a bit unnatural and also:
- `_` has other connotations in JS, generally for unused variables.
- Even if it doesn't, feels like `lodash` has already claimed that sigil, and `frappejs` makes use of `lodash` which leads to some mild confusion.

The design I'm thinking of will augment translation to take advantage of template strings. As of now the sigil is `T`.

Here's a preview of the API design:
```javascript
// To obtain a translated string
T`The value of amount can't be ${amount}`.s

// To provide context
T`The value of amount can't be ${amount}`.ctx('sale').s

// `s` is not strictly required because of toString, so:
T`The value of amount can't be ${amount}`

// 't' is used when the class is not required, also allows backwards compatibility
frappe._ = t;
_("The value of amount can't be {}", amount)
```

Using a class for translation can allow other sorts of augmentations. For example, applying text decorations such as **bold** or _italics_ to args or some string segments.

_Note: This is just the frontend of the translation API, still need to think about the backend._